### PR TITLE
サンデーうぇぶりのWebサイトがOpenしないので、homeの導線をスマホのネイティブアプリに変更

### DIFF
--- a/src/app/home/home.page.html
+++ b/src/app/home/home.page.html
@@ -31,7 +31,7 @@
             <img src="//image.itmedia.co.jp/nl/articles/1408/07/ike_140807genma01.jpg"   (click)="openLink('https://www.amazon.co.jp/s?k=%E5%B9%BB%E9%AD%94%E5%A4%A7%E6%88%A6Rebirth&i=digital-text&s=review-rank&__mk_ja_JP=%E3%82%AB%E3%82%BF%E3%82%AB%E3%83%8A&qid=1561202154&ref=sr_st_review-rank')" />
         </p>
 
-        <p><ion-thumbnail><img src="/assets/genma-taisen-rebirth.jpg" (click)="openLink('https://www.sunday-webry.com/series/748')" /></ion-thumbnail>  <ion-button color="danger" (click)="openLink('https://www.sunday-webry.com/series/748')" >サンデーうぇぶりのWebサイト（Webブラウザ用）は現在なぜか閉局中</ion-button></p>
+        <p><ion-thumbnail><img src="/assets/genma-taisen-rebirth.jpg" (click)="openLink('https://www.sunday-webry.com/series/748')" /></ion-thumbnail>  <ion-button color="danger" (click)="openLink('https://www.sunday-webry.com/series/748')" >サンデーうぇぶりのWebは現在なぜか閉局中</ion-button></p>
 
 
 

--- a/src/app/home/home.page.scss
+++ b/src/app/home/home.page.scss
@@ -4,5 +4,5 @@
 }
 
 .welcome-card  ion-card-content p img {
-   max-width: 10vw;max-height:10vw
+   max-width: 25vw;max-height:25vw
  }


### PR DESCRIPTION
サンデーうぇぶりのWebサイトが近日オープンとか2週間ほど書いておきながら、全然Openしないので、homeの導線をスマホのネイティブアプリに変更